### PR TITLE
Setting instrument_nr in MidiInstument class

### DIFF
--- a/mingus/containers/instrument.py
+++ b/mingus/containers/instrument.py
@@ -253,4 +253,5 @@ class MidiInstrument(Instrument):
 
     def __init__(self, name=''):
         self.name = name
+        self.instrument_nr = self.names.index(name) + 1
 


### PR DESCRIPTION
All instruments created with MidiInstrument class had instrument_nr = 1. To be usable by midi playing classes instrument name supplied in constructor needs to be converted into instrument_nr.